### PR TITLE
fix for login error after Ctrl-C or incorrect startup login

### DIFF
--- a/openad/app/login_manager.py
+++ b/openad/app/login_manager.py
@@ -72,9 +72,9 @@ def load_login_api(cmd_pointer, toolkit_name, reset=False):
                 return login_success, expiry_datetime
             else:
                 if not suppress:
-                    output_error(msg("error_login", toolkit_name, split=True), return_val=False)
+                    output_error(msg("err_login", toolkit_name, split=True), return_val=False)
                 return False, None
 
         except Exception as err:
-            output_error(msg("error_login", err, toolkit_name, split=True), return_val=False)
+            output_error(msg("err_login", err, toolkit_name, split=True), return_val=False)
             return False, None

--- a/openad/app/main.py
+++ b/openad/app/main.py
@@ -768,8 +768,12 @@ def cmd_line():
     for i in sys.argv[1:]:
         inp = inp + a_space + i
         a_space = " "
+    try:
+        command_line = RUNCMD()
+    except KeyboardInterrupt:
+        output_error("Keyboard Initiated Exit before OpenAD Initialised")
+        return
 
-    command_line = RUNCMD()
     # Check for help from a command line request.
     if len(inp.strip()) > 0:
         words = inp.split()

--- a/openad/user_toolkits/DS4SD/login.py
+++ b/openad/user_toolkits/DS4SD/login.py
@@ -116,9 +116,6 @@ def login(cmd_pointer):
             cmd_pointer=cmd_pointer,
             return_val=False,
         )
-        output_error(
-            msg("err_login", "DS4SD", f"system error {e}", split=True), cmd_pointer=cmd_pointer, return_val=False
-        )
         return False, None
 
 
@@ -128,7 +125,7 @@ def get_creds(cred_file, cmd_pointer):
     if api_config is None:
         output_warning("Please Enter in Credentials for Deep Search", cmd_pointer=cmd_pointer, return_val=False)
         output_text(
-            f"Enter the URL / Hostname: if the hostname is left blank it will default to '{DEFAULT_URL} ",
+            f"Enter the URL / Hostname: if the hostname is left blank it will default to '{DEFAULT_URL}' ",
             cmd_pointer=cmd_pointer,
             return_val=False,
         )


### PR DESCRIPTION
Problem:

If user is forced to login to toolkit on startup due to removed file or unable to login system amends without appropriate error checking and does not unset the context of the toolkit.


FIx

Amend output error messaging and error trapping and ensure unset context occurs before exit.