### PR TITLE
DS4SD output cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Ensure you're running Python 3.10 or 3.11. There's multiple ways of updating Pyt
         openad
 
     <!-- ![Landing](assets/screenshot-landing.png) -->
-    <!-- <a href="assets/screenshot-landing.png" target="_blank"><img src="assets/screenshot-landing.png" /></a> -->
+    <!-- <a href="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/screenshot-landing.png" target="_blank"><img src="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/screenshot-landing.png" /></a> -->
 
 -   **Exit the command shell**<br>
     Hit `ctrl+c` or run:
@@ -208,11 +208,11 @@ The following commands only need to be run once after installation:
     Make sure to select the "ad-venv" iPython kernel. You can do this under _Kernel > Change Kernel_, or in the latest versions of Jupyter by clicking the kernel name in the top right hand corner. If you don't see your iPython kernel, make sure you followed the Jupyter Setup instructions listed above.
 
 <figure>
-    <a href="assets/jupyter-notebook-kernel.png" target="_blank"><img src="assets/jupyter-notebook-kernel.png"></a>
+    <a href="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/jupyter-notebook-kernel.png" target="_blank"><img src="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/jupyter-notebook-kernel.png"></a>
     <figcaption align="center" style="font-size:0.9em;opacity:.6;margin-top:-30px;margin-bottom:50px"><i>Jupyter Notebook</i></figcaption>
 </figure>
 <figure>
-    <a href="assets/jupyter-lab-kernel.png" target="_blank"><img src="assets/jupyter-lab-kernel.png"></a>
+    <a href="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/jupyter-lab-kernel.png" target="_blank"><img src="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/jupyter-lab-kernel.png"></a>
     <figcaption align="center" style="font-size:0.9em;opacity:.6;margin-top:-30px;margin-bottom:50px"><i>Jupyter Lab</i></figcaption>
 </figure>
 
@@ -249,7 +249,7 @@ Before you can interact with the toolkits, you'll need to register with each ind
     - Click the "Generate new API key" button<br>
       <br>
       <!-- ![Landing](assets/ds4sd-api-key.png) -->
-      <a href="assets/ds4sd-api-key.png" target="_blank"><img src="assets/ds4sd-api-key.png" /></a>
+      <a href="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/ds4sd-api-key.png" target="_blank"><img src="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/ds4sd-api-key.png" /></a>
 
 1. Once inside the OpenAD client, you'll be prompted to authenticate when activating the Deep Search (DS4SD) toolkit. When running `set context ds4sd` :
 
@@ -274,7 +274,7 @@ Before you can interact with the toolkits, you'll need to register with each ind
     -   Obtain your API key by clicking the user profile icon in the top right hand corner and select "My profile".<br>
         <br>
         <!-- ![Landing](assets/rxn-api-key.png) -->
-        <a href="assets/rxn-api-key.png" target="_blank"><img src="assets/rxn-api-key.png" /></a>
+        <a href="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/rxn-api-key.png" target="_blank"><img src="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/rxn-api-key.png" /></a>
 
 1. When setting the context to RXN using `set context rxn` you'll be prompted to create a new auth configuration file:
 
@@ -328,7 +328,7 @@ To enable our AI assistant, you'll need an account with OpenAI. There is a one m
 
 <!-- ![Landing](readme/openai-api-key.png) -->
 
-<a href="assets/openai-api-key.png" target="_blank"><img src="assets/openai-api-key.png" /></a>
+<a href="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/openai-api-key.png" target="_blank"><img src="https://raw.githubusercontent.com/acceleratedscience/open-ad-toolkit/main/assets/openai-api-key.png" /></a>
 
 <br>
 

--- a/openad/core/lang_workspaces.py
+++ b/openad/core/lang_workspaces.py
@@ -205,7 +205,7 @@ def create_workspace(cmd_pointer, parser):
 
         readline.clear_history()
         readline.write_history_file(cmd_pointer.histfile)
-        # raise ValueError('This is a test error.\n') @Phil this causes the app to break permamenently.
+        # raise ValueError('This is a test error.\n') @later this causes the app to break permamenently.
     except Exception as err:
         error_other = msg("err_workspace_create", err)
 

--- a/openad/flask_apps/dataviewer/css/tabulator_ibm_theme.css
+++ b/openad/flask_apps/dataviewer/css/tabulator_ibm_theme.css
@@ -207,7 +207,6 @@ body {
 	/* Override trunc-3 */
 	display: block;
 	-webkit-line-clamp: 1;
-	background: pink;
 }
 
 /* Overlay displaying full text when clicking on truncated text */

--- a/openad/helpers/general.py
+++ b/openad/helpers/general.py
@@ -306,7 +306,7 @@ def load_module_from_path(module_name, file_path):
 
 
 # Print a terminal-wide separator
-def print_separator(style=None, width=None):
+def print_separator(style=None, width=None, return_val=False):
     from openad.app.global_var_lib import GLOBAL_SETTINGS
 
     if GLOBAL_SETTINGS["display"] == "terminal" or GLOBAL_SETTINGS["display"] == None:
@@ -315,9 +315,9 @@ def print_separator(style=None, width=None):
         terminal_width = shutil.get_terminal_size().columns
         width = terminal_width if not width or terminal_width < width else width
         if style:
-            output_text(f"<{style}>{'-' * width}</{style}>", nowrap=True)
+            return output_text(f"<{style}>{'-' * width}</{style}>", nowrap=True, return_val=return_val)
         else:
-            output_text(f"{'-' * width}", nowrap=True)
+            return output_text(f"{'-' * width}", nowrap=True, return_val=return_val)
 
 
 #

--- a/openad/helpers/h_data.py
+++ b/openad/helpers/h_data.py
@@ -1,0 +1,24 @@
+import os
+import pandas as pd
+
+
+def col_from_df(df, column_name) -> list:
+    """
+    Returns a given dataframe's column as a list object.
+    """
+    print("A")
+    if column_name in df:
+        return df[column_name].tolist()
+    return []
+
+
+def csv_to_df(cmd_pointer, filename):
+    """
+    Returns a dataframe from a csv file.
+    """
+    print("B")
+    if not os.path.isfile(cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + filename):
+        raise Exception("File does not exist")  # pylint: disable=broad-exception-raised
+    else:
+        df = pd.read_csv(cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + filename)
+    return df

--- a/openad/helpers/h_data.py
+++ b/openad/helpers/h_data.py
@@ -6,7 +6,7 @@ def col_from_df(df, column_name) -> list:
     """
     Returns a given dataframe's column as a list object.
     """
-    print("A")
+
     if column_name in df:
         return df[column_name].tolist()
     return []
@@ -16,7 +16,7 @@ def csv_to_df(cmd_pointer, filename):
     """
     Returns a dataframe from a csv file.
     """
-    print("B")
+
     if not os.path.isfile(cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + filename):
         raise Exception("File does not exist")  # pylint: disable=broad-exception-raised
     else:

--- a/openad/helpers/output.py
+++ b/openad/helpers/output.py
@@ -200,7 +200,6 @@ def output_table(
     is_data=True,
     headers=None,
     note=None,
-    tablefmt="simple",
     return_val=None,
     pad=1,
     pad_btm=None,
@@ -226,9 +225,6 @@ def output_table(
         Ignored when table is a dataframe.
     note (str):
         A footnote to display at the bottom of the table.
-    tablefmt (str):
-        The table format used for tabulate (CLI only)
-        See https://github.com/astanin/python-tabulate#table-format
     return_val (None/bool):
         Returns the table instead of displaying it.
         The default (None) results in True for Jupyter and API, False for CLI.
@@ -317,7 +313,7 @@ def output_table(
                 else:
                     headers = table.columns.values.tolist()
 
-            table = tabulate(table, headers=tabulate_headers, tablefmt=tablefmt, showindex=False, numalign="left")
+            table = tabulate(table, headers=tabulate_headers, tablefmt="simple", showindex=False, numalign="left")
         else:
             # Parse styling tags.
             for i, row in enumerate(table):
@@ -325,7 +321,7 @@ def output_table(
                     table[i][j] = style(cell, nowrap=True)
 
             headers = [] if headers is None else headers
-            table = tabulate(table, headers=headers, tablefmt=tablefmt, showindex=False, numalign="left")
+            table = tabulate(table, headers=headers, tablefmt="simple", showindex=False, numalign="left")
 
         # Crop table if it's wider than the terminal.
         max_row_length = max(list(map(lambda row: len(row), table.splitlines())))

--- a/openad/helpers/output.py
+++ b/openad/helpers/output.py
@@ -199,6 +199,7 @@ def output_table(
     table,
     is_data=True,
     headers=None,
+    show_index=False,
     note=None,
     return_val=None,
     pad=1,
@@ -223,6 +224,8 @@ def output_table(
     headers (list):
         A list of strings, where each string is a column header.
         Ignored when table is a dataframe.
+    show_index (bool, default=False):
+        Display the index column in Jupyter.
     note (str):
         A footnote to display at the bottom of the table.
     return_val (None/bool):
@@ -359,6 +362,13 @@ def output_table(
         if is_df_styler_obj:
             table_styler.data = table
             table = table_styler
+
+            # Hide index column in Jupyter, unless we want it.
+            if not show_index:
+                table.hide(axis="index")
+        else:
+            if not show_index:
+                table = table.style.hide(axis="index")
 
         if footnote:
             output_text(footnote, return_val=False)

--- a/openad/helpers/output_msgs.py
+++ b/openad/helpers/output_msgs.py
@@ -64,7 +64,7 @@ _messages = {
     "success_copy": lambda source_file, source_workspace_name, dest_workspace_name: f"Copied the file {source_file} from your {source_workspace_name} to your {dest_workspace_name} workspace",
     "success_delete": lambda file_name, workspace_name: f"Deleted the file {file_name} from your {workspace_name} workspace",
     "success_save_data": lambda file_path: f"Your data was successfully stored as <yellow>{file_path}</yellow>",
-    "success_file_saved": lambda filename=None: f"We successully saved '<yellow>{filename}</yellow>' to your workspace"
+    "success_file_saved": lambda filename=None: f"Successully saved <yellow>{filename}</yellow> to your workspace"
     if filename
     else "File successully saved to your workspace",
     # Warning

--- a/openad/helpers/output_msgs.py
+++ b/openad/helpers/output_msgs.py
@@ -222,7 +222,6 @@ _messages = {
         "<yellow>" + fwd_expr + "</yellow>",
         err,
     ],
-    "err_deepsearch": lambda err: ["There was an error calling DeepSearch", err],
     # endregion
     ##########################################################################
     # region - MOLECULE GRID
@@ -344,12 +343,16 @@ _messages = {
     "err_key_exit_before_init": "Keyboard-initiated exit before OpenAD was initialised",
     "err_routes_required": "Routes are required to launch a Flask server",
     "err_cmd_pointer_required": "output_table(): cmd_pointer is required to enable follow-up commands",
+    "err_pyparsing": [
+        "Unexpected pyparsing error\n<warning>Please screenshot and report circumstance to OpenAD team</warning>",
+        "Restart Notebook kernel or application to proceed",
+    ],
     # endregion
 }
 
 
 # Procure a display message from output_msgs.py.
-def msg(msg_name, *args, split=False):
+def msg(msg_name, *args, custom_messages=None):
     """
     Fetches and formats an output message from the messages dictionary.
 
@@ -361,13 +364,13 @@ def msg(msg_name, *args, split=False):
         Any number of variables that are required for the lambda function.
     """
 
-    # TEMP
-    if split:
-        print("\nxxxxxxxxxxxxxxxxxxxxxxx")
-        print("Remove split for", msg_name)
-        print("xxxxxxxxxxxxxxxxxxxxxxx\n")
-
-    output = _messages[msg_name]
+    # This function can be imported by individual
+    # toolkits with custom _messages parameter set.
+    # See DS4SD for an example.
+    if custom_messages:
+        output = custom_messages[msg_name]
+    else:
+        output = _messages[msg_name]
 
     # Lambda function -> execute to get output.
     if callable(output):

--- a/openad/helpers/output_msgs.py
+++ b/openad/helpers/output_msgs.py
@@ -64,7 +64,9 @@ _messages = {
     "success_copy": lambda source_file, source_workspace_name, dest_workspace_name: f"Copied the file {source_file} from your {source_workspace_name} to your {dest_workspace_name} workspace",
     "success_delete": lambda file_name, workspace_name: f"Deleted the file {file_name} from your {workspace_name} workspace",
     "success_save_data": lambda file_path: f"Your data was successfully stored as <yellow>{file_path}</yellow>",
-    "success_file_saved": "File successully saved to your workspace",
+    "success_file_saved": lambda filename=None: f"We successully saved '<yellow>{filename}</yellow>' to your workspace"
+    if filename
+    else "File successully saved to your workspace",
     # Warning
     "war_no_filename_provided": lambda default: f"No filename provided, reverting to the default '{default}'",
     # Error

--- a/openad/helpers/spinner.py
+++ b/openad/helpers/spinner.py
@@ -2,6 +2,10 @@
 # - - -
 # Inherits all methods from Halo but sets default parameters and adds some styling.
 # Note: text_color='grey' results in black text, so we use our own styling instead.
+#
+# Usage:
+# from openad.helpers.spinner import spinner
+# spinner.start("Please hold while we do something...")
 
 from openad.helpers.general import is_notebook_mode
 from openad.helpers.output import output_text
@@ -16,7 +20,7 @@ class Spinner(Halo):
     def __init__(self):
         # Alternative spinners:
         # simpleDotsScrolling, interval=100
-        super().__init__(spinner="dots", color="white")
+        super().__init__(spinner="triangle", color="white")
 
     def start(self, text=None, no_format=False):
         if no_format:

--- a/openad/molecules/mol_functions.py
+++ b/openad/molecules/mol_functions.py
@@ -155,17 +155,35 @@ def merge_molecule_properties(molecule_dict, mol):
 
 
 def valid_smiles(input_molecule) -> bool:
-    """determines if a molecule is valid"""
-    blocker = rdBase.BlockLogs()
-    input_molecule = Chem.MolFromSmiles(input_molecule, sanitize=False)
-    if input_molecule is None:
+    """Check if an string is valid SMILES definition."""
+
+    blocker = rdBase.BlockLogs()  # pylint: disable=c-extension-no-member
+    try:
+        m = Chem.MolFromSmiles(input_molecule, sanitize=False)  # pylint: disable=no-member
+    except:
+        return False
+    if m is None:
         return False
     else:
         try:
-            Chem.SanitizeMol(input_molecule)
-        except:
+            Chem.SanitizeMol(m)  # pylint: disable=no-member
+        except Exception:  # pylint: disable=broad-exception-caught
             return False
     return True
+
+
+def valid_inchi(input_molecule) -> bool:
+    """Check if a string is valid InChI molecule."""
+
+    blocker = rdBase.BlockLogs()  # pylint: disable=c-extension-no-member
+    try:
+        m = Chem.inchi.InchiToInchiKey(input_molecule)
+    except:
+        return False
+    if m is None:
+        return False
+    else:
+        return True
 
 
 def canonical_smiles(input_molecule):

--- a/openad/plugins/style_parser/style_parser.py
+++ b/openad/plugins/style_parser/style_parser.py
@@ -634,11 +634,9 @@ def _expand_error_success_tags(text, html=False):
 
     # Output for markdown: use HTML tags instead of ANSI codes.
     if html:
-        text = re.sub(r"^<error>(.*?)<\/error>", r'<span style="color: #d00">\1</span>', text, flags=re.MULTILINE)
-        text = re.sub(r"^<success>(.*?)<\/success>", r'<span style="color: #090">\1</span>', text, flags=re.MULTILINE)
-        text = re.sub(
-            r"^<warning>(.*?)<\/warning>", r'<span style="color: #ffa500">\1</span>', text, flags=re.MULTILINE
-        )
+        text = re.sub(r"<error>(.*?)<\/error>", r'<span style="color: #d00">\1</span>', text, flags=re.MULTILINE)
+        text = re.sub(r"<success>(.*?)<\/success>", r'<span style="color: #090">\1</span>', text, flags=re.MULTILINE)
+        text = re.sub(r"<warning>(.*?)<\/warning>", r'<span style="color: #ffa500">\1</span>', text, flags=re.MULTILINE)
 
     # Output for non-styled output: display status as text.
     else:

--- a/openad/plugins/style_parser/style_parser.py
+++ b/openad/plugins/style_parser/style_parser.py
@@ -311,13 +311,13 @@ def tags_to_markdown(text: str):
     text = re.sub(r"<bold>(.*?)<\/bold>", r"**\1**", text)
     text = re.sub(r"<cmd>(.*?)<\/cmd>", r"`\1`", text)
     text = re.sub(r"<red>(.*?)<\/red>", r'<span style="color: #d00">\1</span>', text)
-    text = re.sub(r"<green>(.*?)<\/green>", r'<span style="color: #5b0">\1</span>', text)
+    text = re.sub(r"<green>(.*?)<\/green>", r'<span style="color: #090">\1</span>', text)
     text = re.sub(r"<yellow>(.*?)<\/yellow>", r'<span style="color: #dc0">\1</span>', text)
     text = re.sub(r"<blue>(.*?)<\/blue>", r'<span style="color: #00d">\1</span>', text)
     text = re.sub(r"<magenta>(.*?)<\/magenta>", r'<span style="color: #d07">\1</span>', text)
     text = re.sub(r"<cyan>(.*?)<\/cyan>", r'<span style="color: #0cc">\1</span>', text)
     text = re.sub(r"<on_red>(.*?)<\/on_red>", r'<span style="background: #d00; color: #fff">\1</span>', text)
-    text = re.sub(r"<on_green>(.*?)<\/on_green>", r'<span style="background: #5b0; color: #fff">\1</span>', text)
+    text = re.sub(r"<on_green>(.*?)<\/on_green>", r'<span style="background: #090; color: #fff">\1</span>', text)
     text = re.sub(r"<on_yellow>(.*?)<\/on_yellow>", r'<span style="background: #dc0; color: #fff">\1</span>', text)
     text = re.sub(r"<on_blue>(.*?)<\/on_blue>", r'<span style="background: #00d; color: #fff">\1</span>', text)
     text = re.sub(r"<on_magenta>(.*?)<\/on_magenta>", r'<span style="background: #d07; color: #fff">\1</span>', text)
@@ -635,7 +635,7 @@ def _expand_error_success_tags(text, html=False):
     # Output for markdown: use HTML tags instead of ANSI codes.
     if html:
         text = re.sub(r"^<error>(.*?)<\/error>", r'<span style="color: #d00">\1</span>', text, flags=re.MULTILINE)
-        text = re.sub(r"^<success>(.*?)<\/success>", r'<span style="color: #0d0">\1</span>', text, flags=re.MULTILINE)
+        text = re.sub(r"^<success>(.*?)<\/success>", r'<span style="color: #090">\1</span>', text, flags=re.MULTILINE)
         text = re.sub(
             r"^<warning>(.*?)<\/warning>", r'<span style="color: #ffa500">\1</span>', text, flags=re.MULTILINE
         )

--- a/openad/user_toolkits/DS4SD/fn_display/fn_display_all_collections.py
+++ b/openad/user_toolkits/DS4SD/fn_display/fn_display_all_collections.py
@@ -5,6 +5,13 @@ import numpy as np
 from openad.helpers.output import output_error, output_table, output_success
 from openad.helpers.output_msgs import msg
 
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+from msgs import ds4sd_msg
+
 
 def display_all_collections(inputs: dict, cmd_pointer):
     """
@@ -25,7 +32,7 @@ def display_all_collections(inputs: dict, cmd_pointer):
         collections = api.elastic.list()
         # raise Exception('This is a test error')
     except Exception as err:  # pylint: disable=broad-exception-caught
-        output_error(msg("err_deepsearch", err), return_val=False)
+        output_error(ds4sd_msg("err_deepsearch", err), return_val=False)
         return False
 
     collections.sort(key=lambda c: c.name.lower())

--- a/openad/user_toolkits/DS4SD/fn_display/fn_display_all_collections.py
+++ b/openad/user_toolkits/DS4SD/fn_display/fn_display_all_collections.py
@@ -51,6 +51,6 @@ def display_all_collections(inputs: dict, cmd_pointer):
             cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + results_file, index=False
         )
         df = df.replace(np.nan, "", regex=True)
-        output_success(msg("success_file_saved"), return_val=False, pad_top=1, pad_btm=0)
+        output_success(msg("success_file_saved", results_file), return_val=False, pad_top=1, pad_btm=0)
 
     return output_table(pd.DataFrame(results))

--- a/openad/user_toolkits/DS4SD/fn_display/fn_display_collection_details.py
+++ b/openad/user_toolkits/DS4SD/fn_display/fn_display_collection_details.py
@@ -2,7 +2,13 @@
 # display collection details 'Patents from USPTO'
 
 from openad.helpers.output import output_text, output_error
-from openad.helpers.output_msgs import msg
+
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+from msgs import ds4sd_msg
 
 
 def display_collection_details(inputs: dict, cmd_pointer):
@@ -22,7 +28,7 @@ def display_collection_details(inputs: dict, cmd_pointer):
         collections = api.elastic.list()
         # raise Exception('This is a test error')
     except Exception as err:  # pylint: disable=broad-exception-caught
-        output_error(msg("err_deepsearch", err), return_val=False)
+        output_error(ds4sd_msg("err_deepsearch", err), return_val=False)
         return False
 
     collection = None

--- a/openad/user_toolkits/DS4SD/fn_display/fn_display_collection_matches.py
+++ b/openad/user_toolkits/DS4SD/fn_display/fn_display_collection_matches.py
@@ -68,7 +68,7 @@ def display_collection_matches(inputs: dict, cmd_pointer):
             cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + results_file, index=False
         )
         df = df.replace(np.nan, "", regex=True)
-        output_success(msg("success_file_saved"), return_val=False, pad_top=1, pad_btm=0)
+        output_success(msg("success_file_saved", results_file), return_val=False, pad_top=1, pad_btm=0)
 
     collectives = pd.DataFrame(results)
     return output_table(collectives)

--- a/openad/user_toolkits/DS4SD/fn_display/fn_display_collection_matches.py
+++ b/openad/user_toolkits/DS4SD/fn_display/fn_display_collection_matches.py
@@ -9,6 +9,13 @@ from openad.helpers.output import output_error, output_table, output_success
 from openad.helpers.output_msgs import msg
 from openad.app.global_var_lib import GLOBAL_SETTINGS
 
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+from msgs import ds4sd_msg
+
 
 def display_collection_matches(inputs: dict, cmd_pointer):
     """
@@ -32,7 +39,7 @@ def display_collection_matches(inputs: dict, cmd_pointer):
         collections.sort(key=lambda c: c.name.lower())
         # raise Exception('This is a test error')
     except Exception as err:  # pylint: disable=broad-exception-caught
-        output_error(msg("err_deepsearch", err), return_val=False)
+        output_error(ds4sd_msg("err_deepsearch", err), return_val=False)
         return False
 
     results = []
@@ -57,7 +64,7 @@ def display_collection_matches(inputs: dict, cmd_pointer):
                 )
             # raise RunQueryError(task_id=1, message="This is a test error", error_type="err123", detail='aaa')
         except RunQueryError as err:
-            output_error(msg("err_deepsearch", err), return_val=False)
+            output_error(ds4sd_msg("err_deepsearch", err), return_val=False)
             return False
     if "save_as" in inputs:
         results_file = str(inputs["results_file"])
@@ -70,5 +77,4 @@ def display_collection_matches(inputs: dict, cmd_pointer):
         df = df.replace(np.nan, "", regex=True)
         output_success(msg("success_file_saved", results_file), return_val=False, pad_top=1, pad_btm=0)
 
-    collectives = pd.DataFrame(results)
-    return output_table(collectives)
+    return output_table(pd.DataFrame(results))

--- a/openad/user_toolkits/DS4SD/fn_display/fn_display_collections_in_domains_list.py
+++ b/openad/user_toolkits/DS4SD/fn_display/fn_display_collections_in_domains_list.py
@@ -30,7 +30,6 @@ def display_collections_in_domains_list(inputs: dict, cmd_pointer):
     collections.sort(key=lambda c: c.name.lower())
     from_list = []
     if isinstance(inputs["from_source"], dict) and inputs["from_source"]["from_list"] != None:
-        print(111)
         try:
             from_list = inputs["from_source"]["from_list"]
             # raise Exception('This is a test error')
@@ -91,6 +90,6 @@ def display_collections_in_domains_list(inputs: dict, cmd_pointer):
             cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + results_file, index=False
         )
         df = df.replace(np.nan, "", regex=True)
-        output_success(msg("success_file_saved"), return_val=False, pad_top=1, pad_btm=0)
+        output_success(msg("success_file_saved", results_file), return_val=False, pad_top=1, pad_btm=0)
 
     return output_table(pd.DataFrame(results))

--- a/openad/user_toolkits/DS4SD/fn_display/fn_display_collections_in_domains_list.py
+++ b/openad/user_toolkits/DS4SD/fn_display/fn_display_collections_in_domains_list.py
@@ -6,6 +6,13 @@ import pandas as pd
 from openad.helpers.output import output_error, output_success, output_table
 from openad.helpers.output_msgs import msg
 
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+from msgs import ds4sd_msg
+
 
 def display_collections_in_domains_list(inputs: dict, cmd_pointer):
     """
@@ -24,7 +31,7 @@ def display_collections_in_domains_list(inputs: dict, cmd_pointer):
         collections = api.elastic.list()
         # raise Exception('This is a test error')
     except Exception as err:  # pylint: disable=broad-exception-caught
-        output_error(msg("err_deepsearch", err), return_val=False)
+        output_error(ds4sd_msg("err_deepsearch", err), return_val=False)
         return False
 
     collections.sort(key=lambda c: c.name.lower())
@@ -33,28 +40,16 @@ def display_collections_in_domains_list(inputs: dict, cmd_pointer):
         try:
             from_list = inputs["from_source"]["from_list"]
             # raise Exception('This is a test error')
-        except Exception as err:  # pylint: disable=broad-exception-caught
-            output_error(
-                [
-                    "Unexpected pyparsing error\nRestart Notebook kernel or application to proceed\n<warning>Please screenshot and report circumstance to OpenAD team</warning>",
-                    err,
-                ],
-                return_val=False,
-            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            output_error(msg("err_pyparsing"), return_val=False)
             return False
 
-    elif "from_list" in inputs["from_source"][0] or 1:
+    elif "from_list" in inputs["from_source"][0]:
         try:
             from_list = inputs["from_source"][0]["from_list"]
             # raise Exception('This is a test error')
-        except Exception as err:  # pylint: disable=broad-exception-caught
-            output_error(
-                [
-                    "Unexpected pyparsing error\nRestart Notebook kernel or application to proceed\n<warning>Please screenshot and report circumstance to OpenAD team</warning>",
-                    err,
-                ],
-                return_val=False,
-            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            output_error(msg("err_pyparsing"), return_val=False)
             return False
 
     results = [

--- a/openad/user_toolkits/DS4SD/fn_search/fn_search_collection.py
+++ b/openad/user_toolkits/DS4SD/fn_search/fn_search_collection.py
@@ -10,9 +10,15 @@ import numpy as np
 from deepsearch.cps.client.components.elastic import ElasticDataCollectionSource
 from deepsearch.cps.queries import DataQuery
 from openad.helpers.output import output_text, output_table, output_error
-from openad.helpers.output_msgs import msg
 from openad.app.global_var_lib import GLOBAL_SETTINGS
 from openad.plugins.style_parser import style
+
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+from msgs import ds4sd_msg
 
 aggs = {
     "by_year": {
@@ -182,7 +188,7 @@ def search_collection(inputs: dict, cmd_pointer):
         cursor = api.queries.run_paginated_query(query)
         # raise Exception('This is a test error')
     except Exception as err:  # pylint: disable=broad-exception-caught
-        output_error(msg("err_deepsearch", err), return_val=False)
+        output_error(ds4sd_msg("err_deepsearch", err), return_val=False)
         return False
 
     for result_page in tqdm(cursor, total=expected_pages):

--- a/openad/user_toolkits/DS4SD/fn_search/fn_search_collection.py
+++ b/openad/user_toolkits/DS4SD/fn_search/fn_search_collection.py
@@ -203,7 +203,6 @@ def search_collection(inputs: dict, cmd_pointer):
 
     if is_docs:
         df = pd.json_normalize(all_aggs)
-        df.index = [""]
         if all_aggs != {} and len(df.columns) > 1:
             output_text("<bold>Result distribution by year</bold>", pad_top=1, return_val=False)
             output_table(df.style.set_properties(**{"text-align": "left"}), is_data=False, return_val=False)

--- a/openad/user_toolkits/DS4SD/fn_search/fn_search_molecules_in_patents.py
+++ b/openad/user_toolkits/DS4SD/fn_search/fn_search_molecules_in_patents.py
@@ -139,7 +139,7 @@ def search_molecules_in_patents(inputs: dict, cmd_pointer):
             cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + results_file, index=False
         )
         df = df.replace(np.nan, "", regex=True)
-        output_success(msg("success_file_saved"), return_val=False, pad_top=1, pad_btm=0)
+        output_success(msg("success_file_saved", results_file), return_val=False, pad_top=1, pad_btm=0)
     output_text(
         f"<bold>We found {len(results_table)} molecules that are mentioned in the following patents:</bold>",
         return_val=False,

--- a/openad/user_toolkits/DS4SD/fn_search/fn_search_patents_cont_molecule.py
+++ b/openad/user_toolkits/DS4SD/fn_search/fn_search_patents_cont_molecule.py
@@ -99,7 +99,7 @@ def search_patents_cont_molecule(inputs: dict, cmd_pointer):
             cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + results_file, index=False
         )
         df = df.replace(np.nan, "", regex=True)
-        output_success(msg("success_file_saved"), return_val=False, pad_top=1, pad_btm=0)
+        output_success(msg("success_file_saved", results_file), return_val=False, pad_top=1, pad_btm=0)
     output_text(
         f"<bold>We found {len(results_table)} patents containing the requested {result_type}</bold>",
         return_val=False,

--- a/openad/user_toolkits/DS4SD/fn_search/fn_search_patents_cont_molecule.py
+++ b/openad/user_toolkits/DS4SD/fn_search/fn_search_patents_cont_molecule.py
@@ -1,41 +1,23 @@
 # Example command:
 # search for patents containing molecule 'CC(C)(c1ccccn1)C(CC(=O)O)Nc1nc(-c2c[nH]c3ncc(Cl)cc23)c(C#N)cc1F'
+# search for patents containing molecule 'InChI=1S/C11H16N2OS/c1-4-8(14)7-9(12)11(2,3)10-13-5-6-15-10/h5-7H,4,12H2,1-3H3'
 
 import numpy as np
 import pandas as pd
 from deepsearch.chemistry.queries.molecules import PatentsWithMoleculesQuery
 from deepsearch.chemistry.queries.molecules import MolId, MolIdType
-from rdkit import Chem
 from openad.helpers.output import output_text, output_success, output_warning, output_error, output_table
 from openad.helpers.output_msgs import msg
 from openad.molecules.molecule_cache import create_analysis_record, save_result
-from openad.molecules.mol_functions import canonical_smiles, valid_smiles
+from openad.molecules.mol_functions import canonical_smiles, valid_smiles, valid_inchi
 from openad.molecules.mol_commands import property_retrieve
 
+import os
+import sys
 
-# needs to be migrated into Helper
-
-
-def valid_inchi(input_molecule) -> bool:
-    """
-    Check if an input molecule is valid InChI definition.
-
-    Parameters
-    ----------
-    input_molecule:
-        InChI string
-    """
-    from rdkit import rdBase
-
-    blocker = rdBase.BlockLogs()  # pylint: disable=c-extension-no-member
-    try:
-        m = Chem.inchi.InchiToInchiKey(input_molecule)
-    except:
-        return False
-    if m is None:
-        return False
-    else:
-        return True
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+from msgs import ds4sd_msg
 
 
 def search_patents_cont_molecule(inputs: dict, cmd_pointer):
@@ -77,7 +59,7 @@ def search_patents_cont_molecule(inputs: dict, cmd_pointer):
         resp = api.queries.run(query)
         # raise Exception('This is a test error')
     except Exception as err:  # pylint: disable=broad-exception-caught
-        output_error(msg("err_deepsearch", err), return_val=False)
+        output_error(ds4sd_msg("err_deepsearch", err), return_val=False)
         return False
     results_table = []
 

--- a/openad/user_toolkits/DS4SD/fn_search/fn_search_similar_molecules.py
+++ b/openad/user_toolkits/DS4SD/fn_search/fn_search_similar_molecules.py
@@ -63,7 +63,7 @@ def search_similar_molecules(inputs: dict, cmd_pointer):
             cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + results_file, index=False
         )
         df = df.replace(np.nan, "", regex=True)
-        output_success(msg("success_file_saved"), return_val=False, pad_top=1)
+        output_success(msg("success_file_saved", results_file), return_val=False, pad_top=1)
 
     output_text(
         f"<bold>We found {len(results_table)} molecules similar to the provided SMILES</bold>",

--- a/openad/user_toolkits/DS4SD/fn_search/fn_search_similar_molecules.py
+++ b/openad/user_toolkits/DS4SD/fn_search/fn_search_similar_molecules.py
@@ -13,6 +13,13 @@ from openad.molecules.molecule_cache import create_analysis_record, save_result
 from openad.molecules.mol_functions import valid_smiles
 from openad.app.global_var_lib import GLOBAL_SETTINGS
 
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+from msgs import ds4sd_msg
+
 
 def search_similar_molecules(inputs: dict, cmd_pointer):
     """
@@ -35,7 +42,7 @@ def search_similar_molecules(inputs: dict, cmd_pointer):
         resp = api.queries.run(query)
         # raise Exception('This is a test error')
     except Exception as err:  # pylint: disable=broad-exception-caught
-        output_error(msg("err_deepsearch", err), return_val=False)
+        output_error(ds4sd_msg("err_deepsearch", err), return_val=False)
         return False
     results_table = []
     for row in resp.outputs["molecules"]:
@@ -92,7 +99,7 @@ def search_similar_molecules(inputs: dict, cmd_pointer):
                 smiles_mol = Chem.MolFromSmiles(inputs["smiles"])
                 # raise Exception('This is a test error')
             except Exception as err:  # pylint: disable= broad-exception-caught
-                output_error(["Error verifying SMILES (RDKit)", err], return_val=False)
+                output_error(ds4sd_msg("err_rdkit_smiles", err), return_val=False)
                 return False
 
             mol_img = Chem.Draw.MolToImage(smiles_mol, size=(200, 200))

--- a/openad/user_toolkits/DS4SD/fn_search/fn_search_substructure_molecules.py
+++ b/openad/user_toolkits/DS4SD/fn_search/fn_search_substructure_molecules.py
@@ -77,7 +77,7 @@ def search_substructure_molecules(inputs: dict, cmd_pointer):
             cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + results_file, index=False
         )
         df = df.replace(np.nan, "", regex=True)
-        output_success(msg("success_file_saved"), return_val=False, pad_top=1, pad_btm=0)
+        output_success(msg("success_file_saved", results_file), return_val=False, pad_top=1, pad_btm=0)
     output_text(
         f"<bold>We found {len(results_table)} molecules that contain the provided substructure</bold>",
         return_val=False,

--- a/openad/user_toolkits/DS4SD/fn_search/fn_search_substructure_molecules.py
+++ b/openad/user_toolkits/DS4SD/fn_search/fn_search_substructure_molecules.py
@@ -7,36 +7,17 @@ from rdkit.Chem import PandasTools
 from rdkit import Chem
 from deepsearch.chemistry.queries.molecules import MoleculeQuery
 from deepsearch.chemistry.queries.molecules import MolQueryType
+from openad.molecules.mol_functions import valid_smiles
 from openad.helpers.output import output_text, output_success, output_error, output_table
 from openad.helpers.output_msgs import msg
 from openad.app.global_var_lib import GLOBAL_SETTINGS
 
+import os
+import sys
 
-# needs to be migrated into Helper
-def valid_smiles(input_molecule) -> bool:
-    """
-    Check if an string is valid SMILES definition.
-
-    Parameters
-    ----------
-    input_molecule:
-        smiles string
-    """
-    from rdkit import rdBase
-
-    blocker = rdBase.BlockLogs()  # pylint: disable=c-extension-no-member
-    try:
-        m = Chem.MolFromSmiles(input_molecule, sanitize=False)  # pylint: disable=no-member
-    except:
-        return False
-    if m is None:
-        return False
-    else:
-        try:
-            Chem.SanitizeMol(m)  # pylint: disable=no-member
-        except Exception:  # pylint: disable=broad-exception-caught
-            return False
-    return True
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+from msgs import ds4sd_msg
 
 
 def search_substructure_molecules(inputs: dict, cmd_pointer):
@@ -49,7 +30,7 @@ def search_substructure_molecules(inputs: dict, cmd_pointer):
         resp = api.queries.run(query)
         # raise Exception('This is a test error')
     except Exception as err:  # pylint: disable=broad-exception-caught
-        output_error(msg("err_deepsearch", err), return_val=False)
+        output_error(ds4sd_msg("err_deepsearch", err), return_val=False)
         return False
     results_table = []
     for row in resp.outputs["molecules"]:
@@ -95,7 +76,7 @@ def search_substructure_molecules(inputs: dict, cmd_pointer):
                 smiles_mol = Chem.MolFromSmiles(inputs["smiles"])
                 # raise Exception('This is a test error')
             except Exception as err:  # pylint: disable=broad-exception-caught
-                output_error(["Error verifying SMILES (RDKit)", err], return_val=False)
+                output_error(ds4sd_msg("err_rdkit_smiles", err), return_val=False)
                 return False
 
             display(smiles_mol)

--- a/openad/user_toolkits/DS4SD/msgs.py
+++ b/openad/user_toolkits/DS4SD/msgs.py
@@ -1,0 +1,11 @@
+from openad.helpers.output_msgs import msg
+
+_messages = {
+    "err_deepsearch": lambda err: ["There was an error calling DeepSearch", err],
+    "err_patent_id": lambda err: ["Failed to load valid list from file column 'PATENT ID' or 'patent id'", err],
+    "err_rdkit_smiles": lambda err: ["Error verifying SMILES (RDKit)", err],
+}
+
+
+def ds4sd_msg(msg_name, *args):
+    return msg(msg_name, custom_messages=_messages, *args)

--- a/openad/user_toolkits/RXN/fn_general/fn_interpret_recipe.py
+++ b/openad/user_toolkits/RXN/fn_general/fn_interpret_recipe.py
@@ -31,6 +31,7 @@ def interpret_recipe(inputs: dict, cmd_pointer):
             recipe = handle.read()
     else:
         output_text(f"<soft>Processing paragraph...</soft>", return_val=False, pad_top=1)
+        return
 
     # Print result
     try:

--- a/openad/user_toolkits/RXN/fn_general/fn_interpret_recipe.py
+++ b/openad/user_toolkits/RXN/fn_general/fn_interpret_recipe.py
@@ -1,63 +1,46 @@
-""" Interprets a free text paragraph into a set of Recipe instructions """
+# Example commands:
+# interpret recipe 'A solution of ((1S,2S)-1-{[(methoxymethyl-biphenyl-4-yl)-(2-pyridin-2-yl-cyclopropanecarbonyl)-amino]-methyl}-2-methyl-butyl)-carbamic acid tert-butyl ester (25 mg, 0.045 mmol) and dichloromethane (4 mL) was treated with a solution of HCl in dioxane (4 N, 0.5 mL) and the resulting reaction mixture was maintained at room temperature for 12 h. The reaction was then concentrated to dryness to afford (1R,2R)-2-pyridin-2-yl-cyclopropanecarboxylic acid ((2S,3S)-2-amino-3-methylpentyl)-(methoxymethyl-biphenyl-4-yl)-amide (18 mg, 95% yield) as a white solid.'
+# interpret recipe 'recipe.txt'
+
+
 import os
 import importlib.util as ilu
-from openad.helpers.output import output_text
-from openad.app.global_var_lib import GLOBAL_SETTINGS
-
-list_of_reactions = []
-
-
-def get_include_lib(cmd_pointer):
-    """Import RXN Include Libraries"""
-    folder = cmd_pointer.toolkit_dir + "/RXN" + "/rxn_include.py"
-    file = "rxn_include"
-    spec = ilu.spec_from_file_location(file, folder)
-    rxn = ilu.module_from_spec(spec)
-    spec.loader.exec_module(rxn)
-    rxn_helper = rxn.rxn_helper
-    return rxn_helper
+from openad.helpers.output import output_text, output_error
+from openad.helpers.general import remove_lines
 
 
 def interpret_recipe(inputs: dict, cmd_pointer):
-    """Interprets a free text paragraph into a set of Recipe instructions"""
+    """
+    Interpret a free text paragraph into a recipe list of instructions.
+    """
+
     recipe = inputs["recipe"]
     rxn4chemistry_wrapper = cmd_pointer.login_settings["client"][cmd_pointer.login_settings["toolkits"].index("RXN")]
-    # Prepare the data query
+
+    # Display processing...
     if (
         os.path.isfile(cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + recipe.strip())
         is True
     ):
-        output_text(
-            f"Attempting to Open and Process Recipe in Workspace File: <green> {recipe} </green>",
-            return_val=False,
-        )
+        output_text(f"<soft>Processing the <yellow>{recipe}</yellow> file...</soft>", return_val=False, pad_top=1)
         with open(
             cmd_pointer.workspace_path(cmd_pointer.settings["workspace"].upper()) + "/" + recipe.strip(),
             "r",
             encoding="utf-8",
         ) as handle:
             recipe = handle.read()
+    else:
+        output_text(f"<soft>Processing paragraph...</soft>", return_val=False, pad_top=1)
 
-    if GLOBAL_SETTINGS["display"] == "notebook":
-        from IPython.display import Markdown  # pylint: disable=import-outside-toplevel
+    # Print result
     try:
+        # raise Exception('This is a test error')
         return_result = []
         actios_from_procedure_results = rxn4chemistry_wrapper.paragraph_to_actions(recipe)
-        if GLOBAL_SETTINGS["display"] == "notebook":
-            return_result.append("***See the following actions from the Recipe:***\n")
-        else:
-            return_result.append("See the following actions from the Recipe:\n")
-
+        return_result.append("<bold>Recipe steps:</bold>")
         for index, action in enumerate(actios_from_procedure_results["actions"], 1):
-            if GLOBAL_SETTINGS["display"] == "notebook":
-                return_result.append(f"{index}. {action}\n")
-            else:
-                return_result.append(f"{index}. {action}\n")
-        if GLOBAL_SETTINGS["display"] == "notebook":
-            return Markdown("".join(return_result))
-        else:
-            return output_text("\n" + "".join(return_result) + "\n")
-    except Exception as e:
-        raise Exception(
-            "unable to to turn paragraph to actions:" + str(e)
-        ) from e  # pylint: disable=broad-exception-raised
+            return_result.append(f"{index}. {action}")
+        remove_lines(2)
+        return output_text("\n".join(return_result), pad=1, nowrap=True)
+    except Exception as err:
+        output_error(["Unable to parse the provided paragraph", err], return_val=False)

--- a/openad/user_toolkits/RXN/fn_general/fn_list_models.py
+++ b/openad/user_toolkits/RXN/fn_general/fn_list_models.py
@@ -1,8 +1,8 @@
 # Example command:
 # list rxn models
 
-from openad.helpers.output import output_table
-from openad.app.global_var_lib import GLOBAL_SETTINGS
+import pandas as pd
+from openad.helpers.output import output_table, output_error
 
 
 def list_models(inputs: dict, cmd_pointer):
@@ -11,11 +11,16 @@ def list_models(inputs: dict, cmd_pointer):
     """
 
     rxn4chemistry_wrapper = cmd_pointer.login_settings["client"][cmd_pointer.login_settings["toolkits"].index("RXN")]
-    # Prepare the data query
+
+    # Load models
     try:
         x = rxn4chemistry_wrapper.list_models()
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        raise Exception("unable to load models :" + str(e)) from e  # pylint: disable=broad-exception-raised
+        # raise Exception('This is a test error')
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        output_error(["Unable to load models", err], return_val=False)
+        return
+
+    # Print result
     results = []
     results2 = []
     for i in x:
@@ -26,13 +31,6 @@ def list_models(inputs: dict, cmd_pointer):
         results.append(i)
         results2.append(outstr)
     res_dict = {"Models": results, "versions": results2}
-    import pandas as pd
-
     df = pd.DataFrame.from_dict(res_dict)
-    df.style.hide(axis="index")
-    if GLOBAL_SETTINGS["display"] == "notebook":
-        from IPython.display import HTML
 
-        return HTML(df.to_html(index=False))
-
-    output_table(df, headers=["Models", "Versions"])
+    return output_table(df, headers=["Models", "Versions"])

--- a/openad/user_toolkits/RXN/fn_general/fn_list_models.py
+++ b/openad/user_toolkits/RXN/fn_general/fn_list_models.py
@@ -1,11 +1,15 @@
-"""Lists available RXN Models"""
+# Example command:
+# list rxn models
 
 from openad.helpers.output import output_table
 from openad.app.global_var_lib import GLOBAL_SETTINGS
 
 
 def list_models(inputs: dict, cmd_pointer):
-    """list avilable rxn models"""
+    """
+    List available RXN models
+    """
+
     rxn4chemistry_wrapper = cmd_pointer.login_settings["client"][cmd_pointer.login_settings["toolkits"].index("RXN")]
     # Prepare the data query
     try:

--- a/openad/user_toolkits/RXN/fn_reactions/NEW_fn_predict_reaction_batch_topn.py
+++ b/openad/user_toolkits/RXN/fn_reactions/NEW_fn_predict_reaction_batch_topn.py
@@ -1,0 +1,355 @@
+# Example command:
+# predict reaction topn in batch from list ['BrBr.c1ccc2cc3ccccc3cc2c1CCO' , 'BrBr.c1ccc2cc3ccccc3cc2c1']
+
+import pandas as pd
+from rdkit import Chem
+from rdkit.Chem import AllChem
+from time import sleep
+import importlib.util as include
+from openad.plugins.style_parser import strip_tags
+from openad.helpers.spinner import spinner
+from openad.helpers.output import output_text, output_warning, output_error, output_table
+from openad.helpers.output_msgs import msg
+from openad.helpers.general import print_separator
+from openad.app.global_var_lib import GLOBAL_SETTINGS
+
+# import os
+# import sys
+# parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# sys.path.insert(0, parent_dir)
+# from msgs import ds4sd_msg
+
+
+def get_reaction_from_smiles(
+    reaction_smiles: str,
+) -> Chem.rdChemReactions.ChemicalReaction:  # pylint: disable=no-member
+    """get a reaction from a smiles defined reaction string"""
+    return AllChem.ReactionFromSmarts(reaction_smiles, useSmiles=True)  # pylint: disable=no-member
+
+
+def get_include_lib(cmd_pointer):
+    """load the rxn include libraries"""
+    import importlib.util as ilu
+
+    folder = cmd_pointer.toolkit_dir + "/RXN" + "/rxn_include.py"
+    file = "rxn_include"
+    spec = ilu.spec_from_file_location(file, folder)
+    rxn = ilu.module_from_spec(spec)
+    spec.loader.exec_module(rxn)
+    rxn_helper = rxn.rxn_helper()
+    return rxn_helper
+
+
+def predict_reaction_batch_topn(inputs: dict, cmd_pointer):
+    """
+    Predict top (n) reactions in Batch from a given list of reactions.
+    """
+    top_n = 5
+    rxn_helper = get_include_lib(cmd_pointer)
+    rxn_helper.sync_up_workspace_name(cmd_pointer)
+    rxn_helper.get_current_project(cmd_pointer)
+
+    if GLOBAL_SETTINGS["display"] == "notebook":
+        from halo import HaloNotebook as Halo  # pylint: disable=import-outside-toplevel
+    else:
+        from halo import Halo  # pylint: disable=import-outside-toplevel
+
+    val = "val"
+    if "topn" in inputs:
+        if int(inputs["topn"][val]) > 5:
+            top_n = int(inputs["topn"][val])
+
+    if "ai_model" in inputs:
+        ai_model = inputs["ai_model"][val]
+    else:
+        ai_model = "2020-08-10"
+
+    rxn_helper = get_include_lib(cmd_pointer)
+    ###################################################################################################
+    # getting our input source for the reactions
+
+    if isinstance(inputs["from_source"], dict) and inputs["from_source"]["from_list"] is not None:
+        try:
+            from_list = inputs["from_source"]["from_list"]
+        except Exception:  # pylint: disable=broad-except
+            output_error(msg("err_pyparsing"), return_val=False)
+            return False
+
+    elif "from_list" in inputs["from_source"][0]:
+        try:
+            from_list = inputs["from_source"][0]["from_list"]
+        except Exception:  # pylint: disable=broad-except
+            output_error(msg("err_pyparsing"), return_val=False)
+            return False
+    elif "from_dataframe" in inputs:
+        try:
+            react_frame = cmd_pointer.api_variables[inputs["from_dataframe"]]
+            from_list = rxn_helper.get_column_as_list_from_dataframe(react_frame, "reactions")
+            if from_list == []:
+                raise Exception(
+                    "No Provided reactions, data frame should have column 'reactions'"
+                )  # pylint: disable=broad-exception-raised
+        except Exception:  # pylint: disable=broad-exception-caught
+            output_error(
+                "Could not load valid list from dataframe column 'reactions' ",
+                return_val=False,
+            )
+            return False
+    elif "from_file" in inputs:
+        from_file = inputs["from_file"]
+        try:
+            react_frame = rxn_helper.get_dataframe_from_file(cmd_pointer, from_file)
+            from_list = rxn_helper.get_column_as_list_from_dataframe(react_frame, "reactions")
+            if from_list == []:
+                raise Exception  # pylint: disable=broad-exception-raised
+        except Exception:  # pylint: disable=broad-exception-caught
+            output_error("Could not load valid list from file column 'reactions' ", return_val=False)
+            return False
+
+    if "use_saved" in inputs:
+        use_saved = True
+    else:
+        use_saved = False
+
+    new_from_list = []
+    cached_results = []
+    new_cannonical_list = []
+    cached_cannonical_list = []
+
+    for entry in from_list:
+        error_list = []
+        for i in entry.split("."):
+            if not rxn_helper.valid_smiles(str(i)):
+                error_list.append(i)
+
+        if len(error_list) > 0:
+            df = pd.DataFrame(error_list, columns=["smiles"])
+            output_error(":The following invalid were Smiles Supplied:", return_val=False)
+            output_table(df)
+            output_warning("info: This rection will be skipped: " + entry + " ", return_val=False)
+            continue
+
+        entry_2 = []
+        for i in entry.split("."):
+            entry_2.append(Chem.MolToSmiles(Chem.MolFromSmiles(i), canonical=True))  # pylint: disable=no-member
+
+        result = rxn_helper.retrieve_cache(
+            cmd_pointer, entry_2, "predict_batch_topn" + str(top_n) + "_model" + ai_model
+        )
+        if result is not False and use_saved is True:
+            cached_results.append(result)
+            cached_cannonical_list.append(entry_2)
+        else:
+            new_from_list.append(entry.split("."))
+            new_cannonical_list.append(entry_2)
+    reaction_no = 0
+    output_text("\n", return_val=False)
+    # address already saved results
+    for reaction_predictions in cached_results:
+        output_text(
+            f"<green>Saved Reaction results for:</green> {cached_cannonical_list[reaction_no]}",
+            return_val=False,
+        )
+
+        reaction_no = reaction_no + 1
+        for j, prediction in enumerate(reaction_predictions["results"], 1):
+            product_smiles = ".".join(prediction["smiles"])
+            confidence = prediction["confidence"]
+            output_text(
+                f"<green>         Product(s) </green>{j} {product_smiles}, With confidence {confidence}",
+                return_val=False,
+            )
+        output_text("\n", return_val=False)
+    # if requirement for ask RXN to generate Results
+    if len(new_from_list) > 0:
+        val = "val"
+        from_list = new_from_list
+        retries = 0
+        status = False
+        rxn4chemistry_wrapper = cmd_pointer.login_settings["client"][
+            cmd_pointer.login_settings["toolkits"].index("RXN")
+        ]
+
+        spinner.start("Processing")
+
+        while status is False:
+            try:
+                # spinner.text = "Processing Prediction"
+                sleep(2)
+                predict_rection_batch_response = rxn4chemistry_wrapper.predict_reaction_batch_topn(
+                    precursors_lists=new_from_list,
+                    topn=top_n,
+                    ai_model=ai_model,
+                )
+                status = True
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                retries = retries + 1
+                if retries > 4:
+                    spinner.fail("Unable to process input")
+                    spinner.stop()
+                    output_error(["Server unresponsive", err], return_val=False)
+                    return
+
+        x = {}
+        retries = 0
+        while "predictions" not in x:
+            try:
+                # spinner.text = "Processing Prediction"
+                x = rxn4chemistry_wrapper.get_predict_reaction_batch_topn_results(
+                    predict_rection_batch_response["task_id"]
+                )
+                if "predictions" not in x:
+                    sleep(3)
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                retries = retries + 1
+                if retries > 10:
+                    spinner.fail("Unable to Process")
+                    spinner.stop()
+                    raise Exception("Server unresponsive " + str(e)) from e  # pylint: disable=broad-exception-raised
+
+        reaction_no = 0
+        spinner.stop()
+        output_final = []
+        alphabet = [
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+            "F",
+            "G",
+            "H",
+            "I",
+            "J",
+            "K",
+            "L",
+            "M",
+            "N",
+            "O",
+            "P",
+            "Q",
+            "R",
+            "S",
+            "T",
+            "U",
+            "V",
+            "W",
+            "X",
+            "Y",
+            "Z",
+            "AA",
+            "BB",
+            "CC",
+            "DD",
+            "EE",
+            "FF",
+            "GG",
+            "HH",
+            "II",
+            "JJ",
+            "KK",
+            "LL",
+            "MM",
+            "NN",
+            "OO",
+            "PP",
+            "QQ",
+            "RR",
+            "SS",
+            "TT",
+            "UU",
+            "VV",
+            "WW",
+            "XX",
+            "YY",
+            "ZZ",
+        ]
+
+        # NOT USED BUT MAYBE LATER - see below
+        # table = []
+        # table_headers=['R', '#', 'Input A', 'Input B', 'Prediction', 'Confidence']
+
+        for i, reaction_predictions in enumerate(x["predictions"], 1):
+            input = new_cannonical_list[reaction_no]
+            output = []
+
+            # NOT USED BUT MAYBE LATER - see below
+            # row_shared = [alphabet[i - 1], None, input, input[1]] # Would have to be updated to support > 2
+
+            output.append(f"Reaction predictions for:")
+            for i, mol in enumerate(input):
+                output.append(f"{alphabet[i]}: {mol}")
+            output.append("---")
+            rxn_helper.save_to_results_cache(
+                cmd_pointer,
+                input,
+                reaction_predictions,
+                "predict_batch_topn" + str(top_n) + "_model" + ai_model,
+            )
+            reaction_no = reaction_no + 1
+
+            for j, prediction in enumerate(reaction_predictions["results"], 1):
+                product_smiles = ".".join(prediction["smiles"])
+                confidence = prediction["confidence"]
+                confidence = round(confidence * 100)
+
+                if confidence < 1:
+                    confidence_str = f"<1"
+                else:
+                    confidence_str = f"{confidence:2d}"
+
+                output_line = f"{j} - confidence {confidence_str}% - {product_smiles}"
+
+                # Colorize list results according to confidence.
+                if confidence > 66:
+                    output_line = f"<green>{output_line}</green>"
+                elif confidence > 33:
+                    output_line = f"<yellow>{output_line}</yellow>"
+                elif confidence < 10 > 1:
+                    output_line = f"<soft>{output_line}</soft>"
+                elif confidence < 1:
+                    output_line = f"<soft>{output_line}</soft>"
+
+                output.append(output_line)
+
+                # NOT USED BUT MAYBE LATER - see below
+                # # Create table row
+                # row = row_shared.copy()
+                # row[1] = j
+                # row.append(product_smiles)
+                # row.append(confidence)
+                #
+                # # Colorize table results according to confidence.
+                # if confidence > 66:
+                #     for idx in range(len(row)):
+                #         row[idx] = f'<green>{str(row[idx])}</green>'
+                # elif confidence > 33:
+                #     for idx in range(len(row)):
+                #         row[idx] = f'<yellow>{str(row[idx])}</yellow>'
+                # elif confidence < 10 > 1:
+                #     for idx in range(len(row)):
+                #         row[idx] = f'<soft>{str(row[idx])}</soft>'
+                # elif confidence < 1:
+                #     for idx in range(len(row)):
+                #         row[idx] = f'<soft>< 1</soft>'
+                # table.append(row)
+
+            # Add separator line.
+            list_width = 0
+            for line in output:
+                ll = len(strip_tags(line))
+                if ll > list_width:
+                    list_width = ll
+            sep = print_separator("yellow", list_width, return_val=True)
+            output[len(input) + 1] = sep
+
+            # Add reaction to main output.
+            br = ["", ""] if i > 1 else []
+            output_final = output_final + br + output
+
+        output_text("\n".join(output_final), return_val=False, pad_btm=1)
+
+        # Same information as a table. Decided it's not useful, but could possibly
+        # be re-enabled via a follow-up command. Something like `result as table`
+        # output_table(table, headers=table_headers, return_val=False)
+    return True

--- a/openad/user_toolkits/RXN/fn_reactions/fn_predict_reaction_batch.py
+++ b/openad/user_toolkits/RXN/fn_reactions/fn_predict_reaction_batch.py
@@ -1,11 +1,18 @@
 """Performs Reaction Prediction on a list of Reactions"""
 
 from openad.helpers.output import output_text, output_error, output_warning, output_table
+from openad.helpers.output_msgs import msg
 import pandas as pd
 from rdkit import Chem
 from rdkit.Chem import AllChem
 from time import sleep
 from openad.app.global_var_lib import GLOBAL_SETTINGS
+
+# import os
+# import sys
+# parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# sys.path.insert(0, parent_dir)
+# from msgs import ds4sd_msg
 
 
 def get_reaction_from_smiles(reaction_smiles: str) -> Chem.rdChemReactions.ChemicalReaction:
@@ -53,27 +60,15 @@ def predict_reaction_batch(inputs: dict, cmd_pointer):
     if isinstance(inputs["from_source"], dict) and inputs["from_source"]["from_list"] != None:
         try:
             from_list = inputs["from_source"]["from_list"]
-        except Exception as err:  # pylint: disable=broad-except
-            output_error(
-                [
-                    "Unexpected pyparsing error\nRestart Notebook kernel or application to proceed\n<warning>Please screenshot and report circumstance to OpenAD team</warning>",
-                    err,
-                ],
-                return_val=False,
-            )
+        except Exception:  # pylint: disable=broad-except
+            output_error(msg("err_pyparsing"), return_val=False)
             return False
 
     elif "from_list" in inputs["from_source"][0]:
         try:
             from_list = inputs["from_source"][0]["from_list"]
-        except Exception as err:  # pylint: disable=broad-except
-            output_error(
-                [
-                    "Unexpected pyparsing error\nRestart Notebook kernel or application to proceed\n<warning>Please screenshot and report circumstance to OpenAD team</warning>",
-                    err,
-                ],
-                return_val=False,
-            )
+        except Exception:  # pylint: disable=broad-except
+            output_error(msg("err_pyparsing"), return_val=False)
             return False
     elif "from_dataframe" in inputs:
         try:

--- a/openad/user_toolkits/RXN/fn_reactions/fn_predict_reaction_batch_topn.py
+++ b/openad/user_toolkits/RXN/fn_reactions/fn_predict_reaction_batch_topn.py
@@ -5,7 +5,14 @@ from rdkit.Chem import AllChem
 from time import sleep
 import importlib.util as ilu
 from openad.helpers.output import output_text, output_warning, output_error, output_table
+from openad.helpers.output_msgs import msg
 from openad.app.global_var_lib import GLOBAL_SETTINGS
+
+# import os
+# import sys
+# parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# sys.path.insert(0, parent_dir)
+# from msgs import ds4sd_msg
 
 
 def get_reaction_from_smiles(
@@ -63,27 +70,15 @@ def predict_reaction_batch_topn(inputs: dict, cmd_pointer):
     if isinstance(inputs["from_source"], dict) and inputs["from_source"]["from_list"] is not None:
         try:
             from_list = inputs["from_source"]["from_list"]
-        except Exception as err:  # pylint: disable=broad-except
-            output_error(
-                [
-                    "Unexpected pyparsing error\nRestart Notebook kernel or application to proceed\n<warning>Please screenshot and report circumstance to OpenAD team</warning>",
-                    err,
-                ],
-                return_val=False,
-            )
+        except Exception:  # pylint: disable=broad-except
+            output_error(msg("err_pyparsing"), return_val=False)
             return False
 
     elif "from_list" in inputs["from_source"][0]:
         try:
             from_list = inputs["from_source"][0]["from_list"]
-        except Exception as err:  # pylint: disable=broad-except
-            output_error(
-                [
-                    "Unexpected pyparsing error\nRestart Notebook kernel or application to proceed\n<warning>Please screenshot and report circumstance to OpenAD team</warning>",
-                    err,
-                ],
-                return_val=False,
-            )
+        except Exception:  # pylint: disable=broad-except
+            output_error(msg("err_pyparsing"), return_val=False)
             return False
     elif "from_dataframe" in inputs:
         try:


### PR DESCRIPTION
- Removed `tablefmt` parameter from `output_table()`
- Now hiding index for tables in jupyter and added a `show_index` parameter to `output_table()`
- Isolated `col_from_df` & `csv_to_df` & `valid_inchi` as helper functions
- Centralized some repeated toolkit messages in the main `output_msgs.py`
- Implemented toolkit-localized `msg()` function with its own toolkit-specific repeating messages (see `ds4sd_msg`)
- Cleaned up all DS4SD functions, replaced wrong implemenations of output_table, cleaned up messaging etc.
- Started cleaning output for RXN functions (in progress)
- Updated readme with absolute URLS